### PR TITLE
device-cloud-common: set /etc/sudoers.d's mode to 0750

### DIFF
--- a/recipes-iot/python/device-cloud-common.inc
+++ b/recipes-iot/python/device-cloud-common.inc
@@ -66,7 +66,7 @@ do_install_append() {
 	install -d ${D}/${VAR_DIR}
 	install -d ${D}/${BIN_DIR}
 	install -d ${D}${systemd_unitdir}/system/
-	install -d ${D}/${sysconfdir}/sudoers.d
+	install -d -m 0750 ${D}/${sysconfdir}/sudoers.d
         install -d ${D}${sysconfdir}/init.d
 
 	# sudoers file


### PR DESCRIPTION
Otherwise it conflicted with sudo recipe's /etc/sudoers.d.

Signed-off-by: Robert Yang <liezhi.yang@windriver.com>