### PR TITLE
fix post scriptlet failed warning

### DIFF
--- a/recipes-iot/python/device-cloud-common.inc
+++ b/recipes-iot/python/device-cloud-common.inc
@@ -143,13 +143,8 @@ FILES_${PN} += "${SHARE_DIR} ${VAR_DIR} ${ETC_DIR} ${BIN_DIR}"
 FILES_${PN} += "/etc/sudoers.d/device-cloud ${sysconfdir}/init.d"
 FILES_${PN}-systemd += "${systemd_unitdir}"
 
-
-pkg_postinst_${PN}() {
-#!/bin/sh -e
-if [ x"$D" = "x" ]; then
-    chown -R ${DC_USER}:${DC_GROUP} ${VAR_DIR}
-    chown -R ${DC_USER}:${DC_GROUP} ${ETC_DIR}
-else
-    exit 1
-fi
+pkg_postinst_ontarget_${PN}() {
+     set -e
+     chown -R ${DC_USER}:${DC_GROUP} ${VAR_DIR}
+     chown -R ${DC_USER}:${DC_GROUP} ${ETC_DIR}
 }


### PR DESCRIPTION
Fix below warning:
[log_check] warning: %post(python-device-cloud-1.0-r0.core2_64) scriptlet failed, exit status 1
